### PR TITLE
chore: update provider version to latest

### DIFF
--- a/modules/hana-cloud/hana_cloud.tf
+++ b/modules/hana-cloud/hana_cloud.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     btp = {
       source  = "sap/btp"
-      version = "~> 1.8.0"
+      version = "~>1.10.0"
     }
   }
 }

--- a/provider.tf
+++ b/provider.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "~>1.8.0"
+      version = "~>1.10.0"
     }
     cloudfoundry = {
-      source  = "SAP/cloudfoundry"
-      version = "1.0.0-rc1.depr"
+      source  = "cloudfoundry/cloudfoundry"
+      version = "~>1.3.0"
     }
   }
 }


### PR DESCRIPTION
Update provider version to latest:

- Terraform provider: 1.10.0
- Cloud Foundry Provider: Switch to Cloud Foundry Organization and update version to 1.3.0

Update comprises also the HANA module